### PR TITLE
Added top margin to menu so that upon generation of wallet, the PIVX …

### DIFF
--- a/generate-wallet.html
+++ b/generate-wallet.html
@@ -9944,7 +9944,7 @@ Bitcoin.Util = {
 				
 		#main { position: relative; margin: 0px auto; width: 1010px; color: #000000; } /* removed text-align: center; */
 		#logoback {  background-image:url(images/logo.png); background-position: top left; background-repeat: no-repeat; }
-		#menu { visibility: hidden; font-size: 90%; padding: 0 12px;}
+		#menu { visibility: hidden; font-size: 90%; padding: 0 12px; margin-top: 35px;}
 		
 		#culturemenu { text-align: right; padding: 10px 20px; font-size: 12px; }
 


### PR DESCRIPTION
This is to correct an issue where the PIVX logo was being partially hidden upon wallet creation. In order to keep a professional appearance, I wanted to submit a patch so that it was no longer hidden.

**BEFORE**
<img width="1080" alt="screen shot 2017-12-08 at 6 50 23 pm" src="https://user-images.githubusercontent.com/7254758/33789742-e594f194-dc48-11e7-9310-7bc36ffd1408.png">

**AFTER**
<img width="1037" alt="screen shot 2017-12-08 at 6 49 38 pm" src="https://user-images.githubusercontent.com/7254758/33789741-e577baca-dc48-11e7-948b-72b50395bae3.png">




