### PR TITLE
Replaced reference of the darknet URL with the secure URL of pivx.org

### DIFF
--- a/generate-wallet.html
+++ b/generate-wallet.html
@@ -10909,7 +10909,7 @@ Bitcoin.Util = {
 			</div>
 
             	<span class="item"><b>Security</b></span>
-                <span class="item" style="font-size: 90%;">For secure wallet generation, do not print wallets "live" from darknet-crypto.com<br />Instead, download this generator from GitHub and run the HTML as a "local" file:</span>
+                <span class="item" style="font-size: 90%;">For secure wallet generation, do not print wallets "live" from https://pivx.org<br />Instead, download this generator from GitHub and run the HTML as a "local" file:</span>
 				<span class="item"><a href="https://github.com/PIVX-Project/PIVX-paperwallet" target="_blank" id="footerlabelgithub"><strong>Secure Download</strong> (GitHub ZIP file)</a></span>
                 
                 


### PR DESCRIPTION
There was a reference to an old darknet url. I've updated with a secure link to pivx.org.